### PR TITLE
flag for setting the home dir as the path base

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,9 @@ PLACE=Localhost
 
 In the example above, two environments are used `.env.production` and `.env.development` in addition to a shared `.env` which includes common variables. Notice how the `PLACE` variable gets overridden.
 
+#### Paths to be viewed from home
+Optionally you can pass a `--home` flag, which would base the path of the provided env files from the home dir, in a platform agnostic maner.
+
 The `greet` script can be invoked with
 
 ```bash


### PR DESCRIPTION
This is a proposal for having the option of setting a flag, which would allow us to have the home dir as the base for the provided env paths.

The need for it raises by the fact that a need for a platform independent way of managing the env files.